### PR TITLE
Adjust APICatalog.csproj path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,13 @@ ARG configuration=Release
 WORKDIR /src
 
 # Copy csproj and restore as distinct layers
-COPY ["APICatalog/APICatalog/APICatalog.csproj", "APICatalog/"]
-RUN dotnet restore "APICatalog/APICatalog/APICatalog.csproj"
+COPY ["APICatalog.csproj", "."]
+RUN dotnet restore "APICatalog.csproj"
 
 # Copy the rest of the code
 COPY . .
 
 # Build
-WORKDIR "/src/APICatalog/APICatalog"
 RUN dotnet build "APICatalog.csproj" -c $configuration -o /app/build
 
 # Publish


### PR DESCRIPTION
## Description
<!-- Briefly explain what this PR does, why it is necessary, and the context of the change. -->
This pull request updates the `Dockerfile` to simplify the build process by flattening the directory structure for the `.csproj` file. The main change is to copy the project file directly to the root and adjust the restore and build commands accordingly.
* The `COPY` and `RUN dotnet restore` commands now reference `APICatalog.csproj` in the root directory instead of a nested path, streamlining the Docker build context.
* The working directory is no longer changed to a nested folder before building, reflecting the flattened structure.

## Type of change
- [ ] ✨ New feature
- [ ] 🐛 Bugfix
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [ ] 🛠️ Other (specify)

## Observations
<!-- Add any additional comments or relevant information here for the reviewer (that's me, by the way). -->
