### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,4 +1,7 @@
 name: SonarCloud
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/alexa2me/catalog-api/security/code-scanning/2](https://github.com/alexa2me/catalog-api/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow, either at the root (to apply globally) or at the job level (`jobs.build.permissions`). In this workflow, only two tokens are used: `SONAR_TOKEN` (for SonarCloud, an external service) and `GITHUB_TOKEN` (for GitHub actions, notably to allow PR comments). The minimal permission set should reflect actual requirements. For SonarCloud analysis and making comments on pull requests, the required permission is typically `contents: read` and `pull-requests: write`. Therefore, add the following block just below the workflow name (line 1), before the `on:` block:

```yaml
permissions:
  contents: read
  pull-requests: write
```
This ensures the workflow runs with restricted permissions, only granting write access to pull requests and read access to contents, mitigating the risks of excessive repository privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
