### PR TITLE
Add health check endpoint support

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -66,6 +66,32 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 
 var app = builder.Build();
 
+// Protect healthcheck endpoint with token in header
+var healthToken = Environment.GetEnvironmentVariable("HEALTHCHECK_TOKEN");
+
+app.UseWhen(ctx => ctx.Request.Path.Equals("/healthcheck", StringComparison.OrdinalIgnoreCase), branch =>
+    branch.Use(async (ctx, next) =>
+        {
+            // Block if token is not configured in the environment
+            if (string.IsNullOrEmpty(healthToken))
+            {
+                ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await ctx.Response.WriteAsync("Unauthorized: token not configured");
+                return;
+            }
+
+            // Block if the header is not sent or is different
+            var hasHeader = ctx.Request.Headers.TryGetValue("X-Health-Token", out var provided);
+            if (!hasHeader || !string.Equals(provided.ToString(), healthToken, StringComparison.Ordinal))
+            {
+                ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await ctx.Response.WriteAsync("Unauthorized");
+                return;
+            }
+
+            await next();
+        }));
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {

--- a/Program.cs
+++ b/Program.cs
@@ -8,6 +8,9 @@ DotNetEnv.Env.Load();
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Add health checks
+builder.Services.AddHealthChecks();
+
 // Add services to the container.
 builder.Services.AddControllers().AddJsonOptions(options => options
     .JsonSerializerOptions
@@ -75,5 +78,7 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
+
+app.MapHealthChecks("/healthcheck");
 
 app.Run();


### PR DESCRIPTION
## Description
<!-- Briefly explain what this PR does, why it is necessary, and the context of the change. -->
This pull request introduces health check functionality to the application by registering health check services and exposing a new health check endpoint. These changes help monitor the application's health and readiness.

Health check integration:

* Registered health check services in the application's service container using `builder.Services.AddHealthChecks()` in `Program.cs`.
* Mapped a new `/healthcheck` endpoint to expose health check results using `app.MapHealthChecks("/healthcheck")` in `Program.cs`.

## Type of change
- [x] ✨ New feature
- [ ] 🐛 Bugfix
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [ ] 🛠️ Other (specify)

## Observations
<!-- Add any additional comments or relevant information here for the reviewer (that's me, by the way). -->
